### PR TITLE
Fix interpretation of multitouch report

### DIFF
--- a/linux/drivers/hid/hid-magicmouse.c
+++ b/linux/drivers/hid/hid-magicmouse.c
@@ -659,18 +659,25 @@ static int magicmouse_probe(struct hid_device *hdev,
 	if (id->product == USB_DEVICE_ID_APPLE_MAGICMOUSE ||
 	    id->product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD) {
 		feature_size = sizeof(feature_mt);
-		feature = feature_mt;
+		feature = kmemdup(feature_mt, feature_size, GFP_KERNEL);
 	} else { /* USB_DEVICE_ID_APPLE_MAGICTRACKPAD2 */
 		if (id->vendor == BT_VENDOR_ID_APPLE) {
 			feature_size = sizeof(feature_mt_trackpad2_bt);
-			feature = feature_mt_trackpad2_bt;
+			feature = kmemdup(feature_mt_trackpad2_bt, feature_size,
+					  GFP_KERNEL);
 		} else { /* USB_VENDOR_ID_APPLE */
 			feature_size = sizeof(feature_mt_trackpad2_usb);
-			feature = feature_mt_trackpad2_usb;
+			feature = kmemdup(feature_mt_trackpad2_usb, feature_size,
+					  GFP_KERNEL);
 		}
+	}
+	if (!feature) {
+		ret = -ENOMEM;
+		goto err_stop_hw;
 	}
 	ret = hid_hw_raw_request(hdev, feature[0], feature, feature_size,
 				 HID_FEATURE_REPORT, HID_REQ_SET_REPORT);
+	kfree(feature);
 	if (ret != -EIO && ret != feature_size) {
 		hid_err(hdev, "unable to request touch data (%d)\n", ret);
 		goto err_stop_hw;

--- a/linux/drivers/hid/hid-magicmouse.c
+++ b/linux/drivers/hid/hid-magicmouse.c
@@ -19,6 +19,7 @@
 #include <linux/input/mt.h>
 #include <linux/module.h>
 #include <linux/slab.h>
+#include <linux/usb/input.h>
 
 #include "hid-ids.h"
 
@@ -593,6 +594,14 @@ static int magicmouse_probe(struct hid_device *hdev,
 	struct hid_report *report;
 	int ret;
 	int feature_size;
+	struct usb_interface *intf;
+
+	if (id->vendor == USB_VENDOR_ID_APPLE &&
+	    id->product == USB_DEVICE_ID_APPLE_MAGICTRACKPAD2) {
+		intf = to_usb_interface(hdev->dev.parent);
+		if (intf->cur_altsetting->desc.bInterfaceNumber != 1)
+			return 0;
+	}
 
 	msc = devm_kzalloc(&hdev->dev, sizeof(*msc), GFP_KERNEL);
 	if (msc == NULL) {


### PR DESCRIPTION
This change fixes the interpretation of the multitouch report by getting
the correct tool width, orientation, and finger down state.

It also:
  - Uses input_mt_get_slot_by_key to use the lowest available multitouch
    slot.
  - Consolidates the requests for multitouch mode in the probe function.
  - Enables and reports ABS_X and ABS_Y.
  - Reports ABS_MT_PRESSURE.
  - Sets the correct limits for various axes.
  - Sets the correct X and Y resolutions.
  - Disables some unused evdev axes.